### PR TITLE
solaris does not have flock

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -315,6 +315,7 @@ mrb_file__gethome(mrb_state *mrb, mrb_value klass)
 mrb_value
 mrb_file_flock(mrb_state *mrb, mrb_value self)
 {
+#if !defined(sun)
   mrb_int operation;
   int fd;
 
@@ -339,6 +340,7 @@ mrb_file_flock(mrb_state *mrb, mrb_value self)
         break;
     }
   }
+#endif
   return mrb_fixnum_value(0);
 }
 #endif


### PR DESCRIPTION
allow the gem to be compiled under OpenSolaris/Illumos and probably Solaris.
There must be a better define than "sun" but I am tired of looking for it so this will do...

it should not impact the other supported platforms.
