### PR TITLE
raise an error for flock on solaris

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -276,7 +276,9 @@ mrb_file__gethome(mrb_state *mrb, mrb_value klass)
 mrb_value
 mrb_file_flock(mrb_state *mrb, mrb_value self)
 {
-#if !defined(sun)
+#if defined(sun)
+  mrb_raise(mrb, E_RUNTIME_ERROR, "flock is not supported on Illumos/Solaris");
+#else
   mrb_int operation;
   int fd;
 


### PR DESCRIPTION
I updated the code to raise instead of silently doing nothing under Solaris.
mruby is not meant for basic users anyway so raising an error is, as you said, a lot cleaner.
