### PR TITLE
FIX: IO#sysread occurs SEGV

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -420,7 +420,7 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
   }
 
   if (mrb_nil_p(buf)) {
-    buf = mrb_str_new(mrb, "", maxlen);
+    buf = mrb_str_new(mrb, NULL, maxlen);
   }
   if (RSTRING_LEN(buf) != maxlen) {
     buf = mrb_str_resize(mrb, buf, maxlen);


### PR DESCRIPTION
```
% ./mruby -e 'File.open("/dev/zero").sysread(100000)'
zsh: segmentation fault (core dumped)  ./mruby -e 'File.open("/dev/zero").sysread(100000)'
```

If the 2nd argument of `mrb_str_new()` is not null, `mrb_str_new()` tries to copy from the 2nd argument.
