### PR TITLE
FIX: IO#read create a large number of objects.

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -194,12 +194,12 @@ class IO
 
       if length && (str.size + @buf.size) >= length
         len = length - str.size
-        str += @buf[0, len]
+        str << @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       else
-        str += @buf
+        str << @buf
         @pos += @buf.size
         @buf = ''
       end
@@ -238,18 +238,18 @@ class IO
 
       if limit && (str.size + @buf.size) >= limit
         len = limit - str.size
-        str += @buf[0, len]
+        str << @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       elsif idx = @buf.index(rs)
         len = idx + rs.size
-        str += @buf[0, len]
+        str << @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       else
-        str += @buf
+        str << @buf
         @pos += @buf.size
         @buf = ''
       end


### PR DESCRIPTION
In `IO#read`, `String#+=` is used many times. So it creates a large number of objects and spends many cpu and large memory.

before:

```
% time ./bin/mruby -e 'File.open("/dev/zero").read(10000000); system "grep VmData /proc/#{$$}/status"'
VmData:   225468 kB
./bin/mruby -e   1.78s user 2.59s system 99% cpu 4.375 total
```

after:

```
% time ./bin/mruby -e 'File.open("/dev/zero").read(10000000); system "grep VmData /proc/#{$$}/status"'
VmData:    14520 kB
./bin/mruby -e   0.00s user 0.02s system 98% cpu 0.023 total
```
