### PR TITLE
FIX: IO#read create a large number of objects.

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -183,29 +183,30 @@ class IO
       end
     end
 
-    str = ''
+    array = []
+    start_pos = @pos
     while 1
       begin
         _read_buf
       rescue EOFError => e
-        str = nil if str.empty? and (not length.nil?) and length != 0
+        array = nil if array.empty? and (not length.nil?) and length != 0
         break
       end
 
-      if length && (str.size + @buf.size) >= length
-        len = length - str.size
-        str += @buf[0, len]
+      if length && (@pos - start_pos + @buf.size) >= length
+        len = length - (@pos - start_pos)
+        array.push @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       else
-        str += @buf
+        array.push @buf
         @pos += @buf.size
         @buf = ''
       end
     end
 
-    str
+    array && array.join
   end
 
   def readline(arg = $/, limit = nil)
@@ -227,37 +228,38 @@ class IO
       rs = $/ + $/
     end
 
-    str = ""
+    array = []
+    start_pos = @pos
     while 1
       begin
         _read_buf
       rescue EOFError => e
-        str = nil  if str.empty?
+        array = nil if array.empty?
         break
       end
 
-      if limit && (str.size + @buf.size) >= limit
-        len = limit - str.size
-        str += @buf[0, len]
+      if limit && (@pos - start_pos + @buf.size) >= limit
+        len = limit - (@pos - start_pos)
+        array.push @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       elsif idx = @buf.index(rs)
         len = idx + rs.size
-        str += @buf[0, len]
+        array.push @buf[0, len]
         @pos += len
         @buf = @buf[len, @buf.size - len]
         break
       else
-        str += @buf
+        array.push @buf
         @pos += @buf.size
         @buf = ''
       end
     end
 
-    raise EOFError.new "end of file reached" if str.nil?
+    raise EOFError.new "end of file reached" if array.nil?
 
-    str
+    array.join
   end
 
   def gets(*args)


### PR DESCRIPTION
same as #32 but don't use `String#<<`.

before:

```
% time ./bin/mruby -e 'File.open("/dev/zero").read(10000000); system "grep VmData /proc/#{$$}/status"' 
VmData:   264168 kB
./bin/mruby -e   1.79s user 2.21s system 99% cpu 3.999 total
```

after:

```
% time ./bin/mruby -e 'File.open("/dev/zero").read(10000000); system "grep VmData /proc/#{$$}/status"'
VmData:    27264 kB
./bin/mruby -e   0.00s user 0.02s system 98% cpu 0.020 total
```
