### PR TITLE
Remove mrb_io_s_select typo.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -743,7 +743,7 @@ retry:
         fptr = (struct mrb_io *)mrb_get_datatype(mrb, RARRAY_PTR(except)[i], &mrb_io_type);
         if (FD_ISSET(fptr->fd, ep)) {
           mrb_ary_push(mrb, list, RARRAY_PTR(except)[i]);
-        } else if (fptr->fd2 >= 0 && FD_ISSET(fptr->fd2, wp)) {
+        } else if (fptr->fd2 >= 0 && FD_ISSET(fptr->fd2, ep)) {
           mrb_ary_push(mrb, list, RARRAY_PTR(except)[i]);
         }
       }


### PR DESCRIPTION
Uncovered with a Coverity scan of our project using mruby-io. https://scan8.coverity.com/reports.htm#v26153/p11375/fileInstanceId=6844382&defectInstanceId=2515905&mergedDefectId=121921