### PR TITLE
support for crossbuild for windows (32 bit and 64 bit) using mingw

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -10,5 +10,7 @@ MRuby::Gem::Specification.new('mruby-io') do |spec|
     #spec.cc.include_paths += ["C:/Windows/system/include"]
     spec.linker.library_paths += ["C:/Windows/system"]
   end
-
+  if build.kind_of?(MRuby::CrossBuild) && %w(x86_64-w64-mingw32 i686-w64-mingw32).include?(build.host_target)
+    spec.linker.libraries += ['ws2_32']
+  end
 end


### PR DESCRIPTION
This fixes #17. We're doing cross compiling on Linux to Windows for [mruby-cli](https://github.com/hone/mruby-cli).