### PR TITLE
define PATH_SEPARATOR

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -47,6 +47,11 @@
 #endif
 
 #define FILE_SEPARATOR "/"
+#if defined(_WIN32) || defined(_WIN64)
+  #define PATH_SEPARATOR ";"
+#else
+  #define PATH_SEPARATOR ":"
+#endif
 
 #ifndef LOCK_SH
 #define LOCK_SH 1
@@ -313,5 +318,7 @@ mrb_init_file(mrb_state *mrb)
   mrb_define_const(mrb, cnst, "LOCK_UN", mrb_fixnum_value(LOCK_UN));
   mrb_define_const(mrb, cnst, "LOCK_NB", mrb_fixnum_value(LOCK_NB));
   mrb_define_const(mrb, cnst, "SEPARATOR", mrb_str_new_cstr(mrb, FILE_SEPARATOR));
+  mrb_define_const(mrb, cnst, "PATH_SEPARATOR", mrb_str_new_cstr(mrb, PATH_SEPARATOR));
   mrb_define_const(mrb, cnst, "NULL", mrb_str_new_cstr(mrb, NULL_FILE));
+
 }


### PR DESCRIPTION
Provide a `File::PATH_SEPARATOR` for *nix and windows.