### PR TITLE
enable test

### DIFF
--- a/run_test.rb
+++ b/run_test.rb
@@ -20,6 +20,7 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
 
   conf.gem :git => 'https://github.com/iij/mruby-env.git'
+  conf.enable_test
 
   conf.gem File.expand_path(File.dirname(__FILE__))
 end


### PR DESCRIPTION
`ruby run_test.rb all test` seems not to execute test without this patch.
