### PR TITLE
Fix buffer overflow of `pos` when file-size is too big

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -525,8 +525,7 @@ mrb_value
 mrb_io_sysseek(mrb_state *mrb, mrb_value io)
 {
   struct mrb_io *fptr;
-  int pos;
-  mrb_int offset, whence = -1;
+  mrb_int pos, offset, whence = -1;
 
   mrb_get_args(mrb, "i|i", &offset, &whence);
   if (whence < 0) {


### PR DESCRIPTION
When file-size is too big like 3GiB, `io.seek(0, IO::SEEK_END) ` got sysseek error by buffer overflow of `pos` even if `MRB_INT64` is enabled.