### PR TITLE
Implement IO.pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IO, File module for mruby
 | IO.copy_stream             |          |      |
 | IO.new, IO.for_fd, IO.open |  o  |     |
 | IO.foreach                 |          |      |
-| IO.pipe                    |          |      |
+| IO.pipe                    |    o     |      |
 | IO.popen                   |    o     |      |
 | IO.read                    |    o     |      |
 | IO.readlines               |          |      |

--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -41,6 +41,19 @@ class IO
     end
   end
 
+  def self.pipe(&block)
+    if block
+      begin
+        r, w = IO._pipe
+        yield r, w
+      ensure
+        r.close unless r.closed?
+        w.close unless w.closed?
+      end
+    else
+      IO._pipe
+    end
+  end
 
   def self.read(path, length=nil, offset=nil, opt=nil)
     if not opt.nil?        # 4 arguments


### PR DESCRIPTION
I propose `IO.pipe` like as CRuby.
But encode option was nothing.

And defined internal method `IO._pipe` same as with none block call `IO.pipe`.
Because this is difficult that embed `ensure` in mruby C-API.