### PR TITLE
build on Win32

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -149,6 +149,7 @@ mrb_fd_cloexec(mrb_state *mrb, int fd)
 #endif
 }
 
+#ifndef _WIN32
 static int
 mrb_cloexec_pipe(mrb_state *mrb, int fildes[2])
 {
@@ -175,7 +176,6 @@ mrb_pipe(mrb_state *mrb, int pipes[2])
   return ret;
 }
 
-#ifndef _WIN32
 static int
 mrb_proc_exec(const char *pname)
 {
@@ -670,6 +670,7 @@ mrb_io_read_data_pending(mrb_state *mrb, mrb_value io)
   return 0;
 }
 
+#ifndef _WIN32
 static mrb_value
 mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 {
@@ -705,6 +706,7 @@ mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 
   return mrb_assoc_new(mrb, r, w);
 }
+#endif
 
 static mrb_value
 mrb_io_s_select(mrb_state *mrb, mrb_value klass)
@@ -987,7 +989,9 @@ mrb_init_io(mrb_state *mrb)
   mrb_define_class_method(mrb, io, "for_fd",  mrb_io_s_for_fd,   MRB_ARGS_ANY());
   mrb_define_class_method(mrb, io, "select",  mrb_io_s_select,  MRB_ARGS_ANY());
   mrb_define_class_method(mrb, io, "sysopen", mrb_io_s_sysopen, MRB_ARGS_ANY());
+#ifndef _WIN32
   mrb_define_class_method(mrb, io, "_pipe", mrb_io_s_pipe, MRB_ARGS_NONE());
+#endif
 
   mrb_define_method(mrb, io, "initialize", mrb_io_initialize, MRB_ARGS_ANY());    /* 15.2.20.5.21 (x)*/
   mrb_define_method(mrb, io, "sync",       mrb_io_sync,       MRB_ARGS_NONE());


### PR DESCRIPTION
I tried to build on Win32 environment with AppVeyor CI.

With this fix (and appveyor.yml file on https://github.com/takahashim/mruby-io/commit/8238cf9f57fb4e9cec919ce83d2c12e844fcaf5f ), I made build pass on AppVeyor.
(But some tests are failded and need to fix.)

https://ci.appveyor.com/project/takahashim/mruby-io/build/%2327

I'm not sure support policy of mruby-io on Windows, so this PR might not be useful (especially handling `test/mruby_io_test.c`).   But mruby-io has already had some `_WIN32` conditions, so this PR might not be so bad, I hope.