### PR TITLE
Fix for windows(mingw)

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -27,6 +27,9 @@ class IO
   end
 
   def self.popen(command, mode = 'r', &block)
+    if !self.respond_to?(:_popen)
+      raise NotImplementedError, "popen is not supported on this platform"
+    end
     io = self._popen(command, mode)
     return io unless block
 
@@ -42,6 +45,9 @@ class IO
   end
 
   def self.pipe(&block)
+    if !self.respond_to?(:_pipe)
+      raise NotImplementedError, "pipe is not supported on this platform"
+    end
     if block
       begin
         r, w = IO._pipe

--- a/src/file_test.c
+++ b/src/file_test.c
@@ -128,6 +128,9 @@ mrb_filetest_s_directory_p(mrb_state *mrb, mrb_value klass)
 mrb_value
 mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 {
+#if defined(_WIN32) || defined(_WIN64)
+  mrb_raise(mrb, E_NOTIMP_ERROR, "pipe is not supported on this platform");
+#else
 #ifdef S_IFIFO
 #  ifndef S_ISFIFO
 #    define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
@@ -145,6 +148,7 @@ mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 
 #endif
   return mrb_false_value();
+#endif
 }
 
 /*
@@ -157,6 +161,9 @@ mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 mrb_value
 mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 {
+#if defined(_WIN32) || defined(_WIN64)
+  mrb_raise(mrb, E_NOTIMP_ERROR, "symlink is not supported on this platform");
+#else
 #ifndef S_ISLNK
 #  ifdef _S_ISLNK
 #    define S_ISLNK(m) _S_ISLNK(m)
@@ -184,6 +191,7 @@ mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 #endif
 
   return mrb_false_value();
+#endif
 }
 
 /*
@@ -196,6 +204,9 @@ mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 mrb_value
 mrb_filetest_s_socket_p(mrb_state *mrb, mrb_value klass)
 {
+#if defined(_WIN32) || defined(_WIN64)
+  mrb_raise(mrb, E_NOTIMP_ERROR, "socket is not supported on this platform");
+#else
 #ifndef S_ISSOCK
 #  ifdef _S_ISSOCK
 #    define S_ISSOCK(m) _S_ISSOCK(m)
@@ -223,6 +234,7 @@ mrb_filetest_s_socket_p(mrb_state *mrb, mrb_value klass)
 #endif
 
   return mrb_false_value();
+#endif
 }
 
 /*

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -6,8 +6,8 @@ assert('FileTest TEST SETUP') do
 end
 
 assert("FileTest.directory?") do
-  assert_equal true,  FileTest.directory?("/tmp")
-  assert_equal false, FileTest.directory?("/bin/sh")
+  assert_equal true,  FileTest.directory?(File.join(File._getwd, "mrblib"))
+  assert_equal false, FileTest.directory?(File.join(File._getwd, "README.md"))
 end
 
 assert("FileTest.exist?") do
@@ -23,14 +23,18 @@ assert("FileTest.exist?") do
 end
 
 assert("FileTest.file?") do
-  assert_equal false, FileTest.file?("/tmp")
-  assert_equal true,  FileTest.file?("/bin/sh")
+  assert_equal false, FileTest.file?(File.join(File._getwd, "mrblib"))
+  assert_equal true,  FileTest.file?(File.join(File._getwd, "README.md"))
 end
 
 assert("FileTest.pipe?") do
-  io = IO.popen("ls")
-  assert_equal true,  FileTest.pipe?(io)
-  assert_equal false, FileTest.pipe?("/tmp")
+  begin
+    assert_equal false, FileTest.pipe?("/tmp")
+    io = IO.popen("ls")
+    assert_equal true,  FileTest.pipe?(io)
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert('FileTest.size') do
@@ -61,11 +65,19 @@ assert("FileTest.size?") do
 end
 
 assert("FileTest.socket?") do
-  assert_true FileTest.socket?($mrbtest_io_socketname)
+  begin
+    assert_true FileTest.socket?($mrbtest_io_socketname)
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert("FileTest.symlink?") do
-  assert_true FileTest.symlink?($mrbtest_io_symlinkname)
+  begin
+    assert_true FileTest.symlink?($mrbtest_io_symlinkname)
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert("FileTest.zero?") do

--- a/test/io.rb
+++ b/test/io.rb
@@ -359,15 +359,19 @@ assert('IO#gets - paragraph mode') do
 end
 
 assert('IO.popen') do
-  io = IO.popen("ls")
-  assert_true io.close_on_exec?
-  assert_equal Fixnum, io.pid.class
-  ls = io.read
-  assert_equal ls.class, String
-  assert_include ls, 'AUTHORS'
-  assert_include ls, 'mrblib'
-  io.close
-  io.closed?
+  begin
+    io = IO.popen("ls")
+    assert_true io.close_on_exec?
+    assert_equal Fixnum, io.pid.class
+    ls = io.read
+    assert_equal ls.class, String
+    assert_include ls, 'AUTHORS'
+    assert_include ls, 'mrblib'
+    io.close
+    io.closed?
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert('IO.read') do
@@ -450,43 +454,51 @@ assert('IO#sysseek') do
 end
 
 assert('IO.pipe') do
-  called = false
-  IO.pipe do |r, w|
-    assert_true r.kind_of?(IO)
-    assert_true w.kind_of?(IO)
-    assert_false r.closed?
-    assert_false w.closed?
-    assert_true FileTest.pipe?(r)
-    assert_true FileTest.pipe?(w)
-    assert_nil r.pid
-    assert_nil w.pid
-    assert_true 2 < r.fileno
-    assert_true 2 < w.fileno
-    assert_true r.fileno != w.fileno
-    assert_false r.sync
-    assert_true w.sync
-    assert_equal 8, w.write('test for')
-    assert_equal 'test', r.read(4)
-    assert_equal ' for', r.read(4)
-    assert_equal 5, w.write(' pipe')
-    assert_equal nil, w.close
-    assert_equal ' pipe', r.read
-    called = true
-    assert_raise(IOError) { r.write 'test' }
-    # TODO:
-    # This assert expect raise IOError but got RuntimeError
-    # Because mruby-io not have flag for I/O readable
-    # assert_raise(IOError) { w.read }
-  end
-  assert_true called
+  begin
+    called = false
+    IO.pipe do |r, w|
+      assert_true r.kind_of?(IO)
+      assert_true w.kind_of?(IO)
+      assert_false r.closed?
+      assert_false w.closed?
+      assert_true FileTest.pipe?(r)
+      assert_true FileTest.pipe?(w)
+      assert_nil r.pid
+      assert_nil w.pid
+      assert_true 2 < r.fileno
+      assert_true 2 < w.fileno
+      assert_true r.fileno != w.fileno
+      assert_false r.sync
+      assert_true w.sync
+      assert_equal 8, w.write('test for')
+      assert_equal 'test', r.read(4)
+      assert_equal ' for', r.read(4)
+      assert_equal 5, w.write(' pipe')
+      assert_equal nil, w.close
+      assert_equal ' pipe', r.read
+      called = true
+      assert_raise(IOError) { r.write 'test' }
+      # TODO:
+      # This assert expect raise IOError but got RuntimeError
+      # Because mruby-io not have flag for I/O readable
+      # assert_raise(IOError) { w.read }
+    end
+    assert_true called
 
-  assert_nothing_raised do
-    IO.pipe { |r, w| r.close; w.close }
+    assert_nothing_raised do
+      IO.pipe { |r, w| r.close; w.close }
+    end
+  rescue NotImplementedError => e
+    skip e.message
   end
 end
 
 assert('`cmd`') do
-  assert_equal `echo foo`, "foo\n"
+  begin
+    assert_equal `echo foo`, "foo\n"
+  rescue NotImplementedError => e
+    skip e.message
+  end
 end
 
 assert('IO TEST CLEANUP') do


### PR DESCRIPTION
This PR makes build success on Windows.

* `File.expand_path`: support drive letter and `ALT_SEPARATOR`
* `File.dirname`: support `ALT_SEPARATOR`
* `File.basename`: ditto.
* `IO.popen`: raise `NotImplementedError`
* `IO.pipe`: ditto.
* `` `cmd` ``:  ditto.
* `File#flock`: ditto.
* `FileTest.pipe?`: ditto.
* `FileTest.symlink?`: ditto.
* `FileTest.socket?`: ditto.