### PR TITLE
Should use global variable

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -380,22 +380,22 @@ $stderr = STDERR
 
 module Kernel
   def print(*args)
-    STDOUT.print(*args)
+    $stdout.print(*args)
   end
 
   def puts(*args)
-    STDOUT.puts(*args)
+    $stdout.puts(*args)
   end
 
   def printf(*args)
-    STDOUT.printf(*args)
+    $stdout.printf(*args)
   end
 
   def gets(*args)
-    STDIN.gets(*args)
+    $stdin.gets(*args)
   end
 
   def getc(*args)
-    STDIN.getc(*args)
+    $stdin.getc(*args)
   end
 end


### PR DESCRIPTION
I wrote [mruby-stringio](https://github.com/ksss/mruby-stringio).
But now, We have to overwrite CONST value for get string of wrote by stdout.

```rb
orig = STDOUT
io = StringIO.new
STDOUT = io
puts "hello"
STDOUT = orig
p io.string #=> "hello\n"
```

I expect to use globel variable like this.

```rb
orig = $stdout
io = StringIO.new
$stdout = io
puts "hello"
$stdout = orig
p io.string #=> "hello\n"
```