### PR TITLE
Apparently, in mruby-process gem, Process is now a Module, not a Class

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -78,7 +78,7 @@ io_set_process_status(mrb_state *mrb, pid_t pid, int status)
 
   c_status = NULL;
   if (mrb_class_defined(mrb, "Process")) {
-    c_process = mrb_class_get(mrb, "Process");
+    c_process = mrb_module_get(mrb, "Process");
     if (mrb_const_defined(mrb, mrb_obj_value(c_process), mrb_intern_cstr(mrb, "Status"))) {
       c_status = mrb_class_get_under(mrb, c_process, "Status");
     }


### PR DESCRIPTION
Hello. With recent mruby, I had this error:

```
wrong argument type Module (expected Class)
```

when closing a pipe (line 40 in io.rb). I tracked this down to line 81 in io.c. In io_set_process_status, there is this line:

```c
    c_process = mrb_class_get(mrb, "Process");
```
In the current code from the mruby-process gem, Process is a module, not a class. I thus needed to change this last line to

```c
    c_process = mrb_module_get(mrb, "Process");
```
This solves my problem. I *presume* that this is the appropriate fix. 

Carlo