### PR TITLE
Fix some spec for IO#sysread

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -625,6 +625,9 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
   if (maxlen < 0) {
     return mrb_nil_value();
   }
+  else if (maxlen == 0) {
+    return mrb_str_new(mrb, NULL, maxlen);
+  }
 
   if (mrb_nil_p(buf)) {
     buf = mrb_str_new(mrb, NULL, maxlen);

--- a/src/io.c
+++ b/src/io.c
@@ -623,7 +623,7 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
 
   mrb_get_args(mrb, "i|S", &maxlen, &buf);
   if (maxlen < 0) {
-    return mrb_nil_value();
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative expanding string size");
   }
   else if (maxlen == 0) {
     return mrb_str_new(mrb, NULL, maxlen);

--- a/src/io.c
+++ b/src/io.c
@@ -636,7 +636,7 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
     buf = mrb_str_resize(mrb, buf, maxlen);
   }
 
-  fptr = (struct mrb_io *)mrb_get_datatype(mrb, io, &mrb_io_type);
+  fptr = (struct mrb_io *)io_get_open_fptr(mrb, io);
   ret = read(fptr->fd, RSTRING_PTR(buf), maxlen);
   switch (ret) {
     case 0: /* EOF */

--- a/test/io.rb
+++ b/test/io.rb
@@ -235,6 +235,7 @@ assert('IO.sysopen, IO#sysread') do
   end
   io.close
   assert_equal "", io.sysread(0)
+  assert_raise(IOError) { io.sysread(1) }
   io.closed?
 end
 

--- a/test/io.rb
+++ b/test/io.rb
@@ -236,6 +236,7 @@ assert('IO.sysopen, IO#sysread') do
   io.close
   assert_equal "", io.sysread(0)
   assert_raise(IOError) { io.sysread(1) }
+  assert_raise(ArgumentError) { io.sysread(-1) }
   io.closed?
 end
 

--- a/test/io.rb
+++ b/test/io.rb
@@ -234,6 +234,7 @@ assert('IO.sysopen, IO#sysread') do
     io.sysread(10000)
   end
   io.close
+  assert_equal "", io.sysread(0)
   io.closed?
 end
 


### PR DESCRIPTION
- IO#sysread with 0 always return empty string
- IO#sysread should raise IOError when closed
- IO#sysread should raise error when invalid pos