### PR TITLE
IO#sysread Check for readable

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -637,6 +637,9 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
   }
 
   fptr = (struct mrb_io *)io_get_open_fptr(mrb, io);
+  if (!fptr->readable) {
+    mrb_raise(mrb, E_IO_ERROR, "not opened for reading");
+  }
   ret = read(fptr->fd, RSTRING_PTR(buf), maxlen);
   switch (ret) {
     case 0: /* EOF */

--- a/test/io.rb
+++ b/test/io.rb
@@ -238,6 +238,11 @@ assert('IO.sysopen, IO#sysread') do
   assert_raise(IOError) { io.sysread(1) }
   assert_raise(ArgumentError) { io.sysread(-1) }
   io.closed?
+
+  fd = IO.sysopen $mrbtest_io_wfname, "w"
+  io = IO.new fd, "w"
+  assert_raise(IOError) { io.sysread(1) }
+  io.close
 end
 
 assert('IO.sysopen, IO#syswrite') do


### PR DESCRIPTION
Actual

```
$ mruby -e 'IO.pipe { |r,w| w.sysread(1) }'
-e:1:sysread failed (RuntimeError)

$ mruby -e 'IO.pipe { |r,w| r.syswrite("") }'
-e:1:not opened for writing (IOError)
```

Expect

```
$ ruby -e 'IO.pipe { |r,w| w.sysread(1) }'
-e:1:in `sysread': not opened for reading (IOError)

$ ruby -e 'IO.pipe { |r,w| r.syswrite("") }'
-e:1:in `syswrite': not opened for writing (IOError)
```