### PR TITLE
To accurate `pos`

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -389,7 +389,6 @@ mrb_io_s_popen(mrb_state *mrb, mrb_value klass)
       }
 
       mrb_iv_set(mrb, io, mrb_intern_cstr(mrb, "@buf"), mrb_str_new_cstr(mrb, ""));
-      mrb_iv_set(mrb, io, mrb_intern_cstr(mrb, "@pos"), mrb_fixnum_value(0));
 
       fptr = mrb_io_alloc(mrb);
       fptr->fd = fd;
@@ -443,7 +442,6 @@ mrb_io_initialize(mrb_state *mrb, mrb_value io)
   flags = mrb_io_modestr_to_flags(mrb, mrb_string_value_cstr(mrb, &mode));
 
   mrb_iv_set(mrb, io, mrb_intern_cstr(mrb, "@buf"), mrb_str_new_cstr(mrb, ""));
-  mrb_iv_set(mrb, io, mrb_intern_cstr(mrb, "@pos"), mrb_fixnum_value(0));
 
   fptr = (struct mrb_io *)DATA_PTR(io);
   if (fptr != NULL) {
@@ -801,7 +799,6 @@ mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 
   r = mrb_obj_value(mrb_data_object_alloc(mrb, mrb_class_ptr(klass), NULL, &mrb_io_type));
   mrb_iv_set(mrb, r, mrb_intern_cstr(mrb, "@buf"), mrb_str_new_cstr(mrb, ""));
-  mrb_iv_set(mrb, r, mrb_intern_cstr(mrb, "@pos"), mrb_fixnum_value(0));
   fptr_r = mrb_io_alloc(mrb);
   fptr_r->fd = pipes[0];
   fptr_r->readable = 1;
@@ -812,7 +809,6 @@ mrb_io_s_pipe(mrb_state *mrb, mrb_value klass)
 
   w = mrb_obj_value(mrb_data_object_alloc(mrb, mrb_class_ptr(klass), NULL, &mrb_io_type));
   mrb_iv_set(mrb, w, mrb_intern_cstr(mrb, "@buf"), mrb_str_new_cstr(mrb, ""));
-  mrb_iv_set(mrb, w, mrb_intern_cstr(mrb, "@pos"), mrb_fixnum_value(0));
   fptr_w = mrb_io_alloc(mrb);
   fptr_w->fd = pipes[1];
   fptr_w->readable = 0;


### PR DESCRIPTION
pos shouldn't cache because it's not controllable.

For example, It's unexpected behavior.

```rb
File.open("tempfile", "w") do |f|
  f.syswrite("abc")
  f.pos #=> Expect 3, got 0
end
```

Not only that, Another case...

```rb
File.open("tempfile", "w") do |f|
  write_method(f.fileno) # write_method use system call write(2) from fd
  f.pos #=> ?
end
```

And CRuby's `IO#pos` doesn't use cache value.

https://github.com/ruby/ruby/blob/5aff6f294821574e54f458d547cf9641dd2eca98/io.c#L1629

So, I propose this patch. 