### PR TITLE
Support outbuf argument for IO#read

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -181,7 +181,7 @@ class IO
     nil
   end
 
-  def read(length = nil)
+  def read(length = nil, outbuf = "")
     unless length.nil?
       unless length.is_a? Fixnum
         raise TypeError.new "can't convert #{length.class} into Integer"
@@ -217,7 +217,12 @@ class IO
       end
     end
 
-    array && array.join
+    if array.nil?
+      outbuf.replace("")
+      nil
+    else
+      outbuf.replace(array.join)
+    end
   end
 
   def readline(arg = $/, limit = nil)


### PR DESCRIPTION
```rb
File.open("foo.md") do |f|
  buf = "Hello, "
  res = f.read(nil, buf)
  p buf #=> "World!"
  p res.object_id == buf.object_id #=> true
  p f.read(1, buf) #=> nil
  p buf #=> ""
end
```

See also https://docs.ruby-lang.org/en/2.4.0/IO.html#method-i-read
