### PR TITLE
Reseek when write

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -123,6 +123,10 @@ class IO
   def write(string)
     str = string.is_a?(String) ? string : string.to_s
     return str.size unless str.size > 0
+    if 0 < @buf.length
+      # reset real pos ignore buf
+      seek(pos, SEEK_SET)
+    end
     len = syswrite(str)
     @pos += len
     len

--- a/test/io.rb
+++ b/test/io.rb
@@ -181,6 +181,16 @@ assert('IO#write', '15.2.20.5.20') do
   io = IO.open(IO.sysopen($mrbtest_io_wfname))
   assert_equal 0, io.write("")
   io.close
+
+  io = IO.open(IO.sysopen($mrbtest_io_wfname, "r+"), "r+")
+  assert_equal 7, io.write("abcdefg")
+  io.rewind
+  assert_equal "ab", io.read(2)
+  assert_equal 3, io.write("123")
+  io.rewind
+  assert_equal "ab123fg", io.read
+  io.close
+
   true
 end
 


### PR DESCRIPTION
This patch fix the following bugs.

```rb
io = IO.open(IO.sysopen($mrbtest_io_wfname, "r+"), "r+")
io.write("abcdefg")
io.rewind
io.read(2)
io.write("123")
io.rewind
io.read #=> Expect "ab123fg", got "abcdefg123"
io.close
```