### PR TITLE
Fix for IO#read(n) with n > IO::BUF_SIZE

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -205,10 +205,12 @@ class IO
         break
       end
 
-      if length && length <= @buf.size
-        array.push @buf[0, length]
-        @buf = @buf[length, @buf.size - length]
-        break
+      if length
+        consume = (length <= @buf.size) ? length : @buf.size
+        array.push @buf[0, consume]
+        @buf = @buf[consume, @buf.size - consume]
+        length -= consume
+        break if length == 0
       else
         array.push @buf
         @buf = ''

--- a/test/io.rb
+++ b/test/io.rb
@@ -140,6 +140,13 @@ assert('IO#read', '15.2.20.5.14') do
   end
 end
 
+assert "IO#read(n) with n > IO::BUF_SIZE" do
+  r,w = IO.pipe
+  n = IO::BUF_SIZE+1
+  w.write 'a'*n
+  assert_equal r.read(n), 'a'*n
+end
+
 assert('IO#readchar', '15.2.20.5.15') do
   # almost same as IO#getc
   IO.open(IO.sysopen($mrbtest_io_rfname)) do |io|


### PR DESCRIPTION
Fixes #87. The error was caused by not reducing the number of bytes to read from the internal buffer for consecutive iterations of the `while 1` loop inside `IO#read`.