### PR TITLE
Handle shared/frozen strings in IO#sysread

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -630,8 +630,13 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
   if (mrb_nil_p(buf)) {
     buf = mrb_str_new(mrb, NULL, maxlen);
   }
+
+  mrb_str_modify(mrb, RSTRING(buf));
+
   if (RSTRING_LEN(buf) != maxlen) {
     buf = mrb_str_resize(mrb, buf, maxlen);
+  } else {
+    mrb_str_modify(mrb, RSTRING(buf));
   }
 
   fptr = (struct mrb_io *)io_get_open_fptr(mrb, io);

--- a/src/io.c
+++ b/src/io.c
@@ -631,8 +631,6 @@ mrb_io_sysread(mrb_state *mrb, mrb_value io)
     buf = mrb_str_new(mrb, NULL, maxlen);
   }
 
-  mrb_str_modify(mrb, RSTRING(buf));
-
   if (RSTRING_LEN(buf) != maxlen) {
     buf = mrb_str_resize(mrb, buf, maxlen);
   } else {

--- a/test/io.rb
+++ b/test/io.rb
@@ -250,6 +250,11 @@ assert('IO.sysopen, IO#sysread') do
     io.sysread(10000)
     io.sysread(10000)
   end
+
+  assert_raise RuntimeError do
+    io.sysread(5, "abcde".freeze)
+  end
+
   io.close
   assert_equal "", io.sysread(0)
   assert_raise(IOError) { io.sysread(1) }


### PR DESCRIPTION
Hi!

Since the new shared strings [have been introduced](https://github.com/mruby/mruby/commit/7edbe428caca6814841195a3f2720745cf04353e), the test below has been failing:

```ruby
assert('IO.sysopen, IO#sysread') do
  fd = IO.sysopen $mrbtest_io_rfname
  io = IO.new fd

  # this is FSHARED string
  str1 = "     "
  str2 = io.sysread(5, str1)
  assert_equal $mrbtest_io_msg[0,5], str1
  assert_equal $mrbtest_io_msg[0,5], str2
  ...
end
```

The commit provides a fix (we should explicitly call `mrb_str_modify` if we're going to modify the string).

And also I've added a test for frozen strings.