### PR TITLE
make `rename` behavior consistent with MRI

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -119,9 +119,11 @@ mrb_file_s_rename(mrb_state *mrb, mrb_value obj)
   src = mrb_string_value_cstr(mrb, &from);
   dst = mrb_string_value_cstr(mrb, &to);
   if (rename(src, dst) < 0) {
+#if defined(_WIN32) || defined(_WIN64)
     if (CHMOD(dst, 0666) == 0 && UNLINK(dst) == 0 && rename(src, dst) == 0) {
       return mrb_fixnum_value(0);
     }
+#endif
     mrb_sys_fail(mrb, mrb_str_to_cstr(mrb, mrb_format(mrb, "(%S, %S)", from, to)));
   }
   return mrb_fixnum_value(0);


### PR DESCRIPTION
Only on Windows does MRI try to rename the file with altered file attributes in case the first attempt to `rename` fails.

This PR makes the behavior of mruby-io consitent to that behavior.

The bonus here is that the change eliminates the chance of the named file disappearing from the directory (which, in the current code, happens in the brief moment between calls to `UNLINK` and `rename`).